### PR TITLE
Add store event models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,14 @@
       <artifactId>quarkus-kafka-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/commonjava/event/common/EventMetadata.java
+++ b/src/main/java/org/commonjava/event/common/EventMetadata.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.event.common;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -25,8 +27,10 @@ import java.util.Map;
 
 public class EventMetadata implements Iterable<Map.Entry<Object, Object>>, Externalizable
 {
+    @JsonProperty("pacakgeType")
     private String packageType;
-    private Map<Object, Object> metadata = new HashMap();
+    @JsonProperty("metadata")
+    private Map<Object, Object> metadata = new HashMap<>();
 
     public EventMetadata() {
         this.packageType = "maven";

--- a/src/main/java/org/commonjava/event/store/AbstractIndyStoreEvent.java
+++ b/src/main/java/org/commonjava/event/store/AbstractIndyStoreEvent.java
@@ -16,6 +16,7 @@
 package org.commonjava.event.store;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
+import jdk.jfr.EventType;
 import org.commonjava.event.common.EventMetadata;
 
 import java.util.Arrays;
@@ -64,7 +65,7 @@ public abstract class AbstractIndyStoreEvent
         return storeKeys;
     }
 
-    @JsonSetter("keys")
+    @JsonSetter( "keys" )
     public final void setKeys( Collection<EventStoreKey> keys )
     {
         this.storeKeys = keys;
@@ -86,6 +87,15 @@ public abstract class AbstractIndyStoreEvent
     public final Iterator<EventStoreKey> iterator()
     {
         return storeKeys.iterator();
+    }
+
+    protected void checkEventType( StoreEventType expected, StoreEventType actual )
+    {
+        if ( expected != actual )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Wrong event type! Should be %s but is %s", expected, actual ) );
+        }
     }
 
 }

--- a/src/main/java/org/commonjava/event/store/AbstractIndyStoreEvent.java
+++ b/src/main/java/org/commonjava/event/store/AbstractIndyStoreEvent.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Base class for events related to changes in Indy ArtifactStore definitions.
+ */
+public abstract class AbstractIndyStoreEvent
+        implements IndyStoreEvent
+{
+
+    private EventMetadata eventMetadata;
+
+    protected Collection<EventStoreKey> storeKeys;
+
+    protected AbstractIndyStoreEvent()
+    {
+    }
+
+    protected AbstractIndyStoreEvent( final EventMetadata eventMetadata, final Collection<EventStoreKey> storeKeys )
+    {
+        this.eventMetadata = eventMetadata;
+        this.storeKeys = storeKeys == null ? Collections.emptySet() : clearNulls( storeKeys );
+    }
+
+    protected AbstractIndyStoreEvent( final EventMetadata eventMetadata, final EventStoreKey... keys )
+    {
+        this.eventMetadata = eventMetadata;
+        this.storeKeys =
+                keys == null || keys.length == 0 ? Collections.emptySet() : clearNulls( Arrays.asList( keys ) );
+    }
+
+    public static Collection<EventStoreKey> clearNulls( final Collection<EventStoreKey> storeKeys )
+    {
+        return storeKeys.stream().filter( Objects::nonNull ).collect( Collectors.toSet() );
+    }
+
+    @Override
+    public final Collection<EventStoreKey> getKeys()
+    {
+        return storeKeys;
+    }
+
+    @JsonSetter("keys")
+    public final void setKeys( Collection<EventStoreKey> keys )
+    {
+        this.storeKeys = keys;
+    }
+
+    @Override
+    public EventMetadata getEventMetadata()
+    {
+        return eventMetadata;
+    }
+
+    @JsonSetter( "eventMetadata" )
+    public final void setEventMetadata( EventMetadata metadata )
+    {
+        this.eventMetadata = metadata;
+    }
+
+    @Override
+    public final Iterator<EventStoreKey> iterator()
+    {
+        return storeKeys.iterator();
+    }
+
+}

--- a/src/main/java/org/commonjava/event/store/AbstractStoreUpdateEvent.java
+++ b/src/main/java/org/commonjava/event/store/AbstractStoreUpdateEvent.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Event signaling that one or more specified ArtifactStore instances' configurations were changed. The {@link StoreUpdateType}
+ * gives more information about the nature of the update.
+ */
+public abstract class AbstractStoreUpdateEvent
+        extends AbstractIndyStoreEvent
+{
+
+    @JsonProperty("updateType")
+    private final StoreUpdateType type;
+
+    @JsonProperty("changeMap")
+    private final Map<EventStoreKey, EventStoreKey> changeMap;
+
+    protected AbstractStoreUpdateEvent( final StoreUpdateType type, final EventMetadata metadata,
+                                        final Map<EventStoreKey, EventStoreKey> changeMap )
+    {
+        super( metadata, changeMap.keySet() );
+        this.changeMap = cloneOriginals( changeMap );
+        this.type = type;
+    }
+
+    private Map<EventStoreKey, EventStoreKey> cloneOriginals( Map<EventStoreKey, EventStoreKey> changeMap )
+    {
+        Map<EventStoreKey, EventStoreKey> cleaned = new HashMap<>();
+        changeMap.forEach( ( key, value ) -> {
+            if ( key != null && value != null )
+            {
+                cleaned.put( key, value.copyOf() );
+            }
+        } );
+
+        return cleaned;
+    }
+
+    public EventStoreKey getOriginal( EventStoreKey store )
+    {
+        return changeMap.get( store );
+    }
+
+    public Map<EventStoreKey, EventStoreKey> getChangeMap()
+    {
+        return changeMap;
+    }
+
+    /**
+     * Return the type of update that took place.
+     */
+    public StoreUpdateType getType()
+    {
+        return type;
+    }
+
+    /**
+     * Return the changed ArtifactStore's specified in this event.
+     */
+    @JsonIgnore
+    public Collection<EventStoreKey> getChanges()
+    {
+        return getKeys();
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName() + "{changed=" + getChanges() + ",type=" + type + '}';
+    }
+}

--- a/src/main/java/org/commonjava/event/store/EventStoreKey.java
+++ b/src/main/java/org/commonjava/event/store/EventStoreKey.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class EventStoreKey
+{
+    @JsonIgnore
+    private String packageType;
+
+    @JsonIgnore
+    private String storeType;
+
+    @JsonIgnore
+    private String storeName;
+
+    protected EventStoreKey()
+    {
+    }
+
+    public EventStoreKey( final String packageType, final String storeType, final String storeName )
+    {
+        this.packageType = packageType;
+        this.storeType = storeType;
+        this.storeName = storeName;
+    }
+
+    public String getPackageType()
+    {
+        return packageType;
+    }
+
+    public void setPackageType( String packageType )
+    {
+        this.packageType = packageType;
+    }
+
+    public String getStoreType()
+    {
+        return storeType;
+    }
+
+    public void setStoreType( String storeType )
+    {
+        this.storeType = storeType;
+    }
+
+    public String getStoreName()
+    {
+        return storeName;
+    }
+
+    public void setStoreName( String storeName )
+    {
+        this.storeName = storeName;
+    }
+
+    public EventStoreKey copyOf()
+    {
+        return new EventStoreKey( this.packageType, this.storeType, this.storeName );
+    }
+
+    public static EventStoreKey fromString( final String id )
+    {
+        String[] parts = id.split( ":" );
+
+        String packageType = null;
+        String name;
+        String type = null;
+
+        // FIXME: We need to get to a point where it's safe for this to be an error and not default to maven.
+        if ( parts.length < 2 )
+        {
+            packageType = "maven";
+            type = "remote";
+            name = id;
+        }
+        else if ( parts.length < 3 || isBlank( parts[0] ) )
+        {
+            packageType = "maven";
+            type = parts[0];
+            name = parts[1];
+        }
+        else
+        {
+            packageType = parts[0];
+            type = parts[1];
+            name = parts[2];
+        }
+
+        if ( type == null )
+        {
+            throw new IllegalArgumentException( "Invalid StoreType: " + parts[1] );
+        }
+
+        return new EventStoreKey( packageType, type, name );
+    }
+
+    @Override
+    public final int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( packageType == null ) ? 7 : packageType.hashCode() );
+        result = prime * result + ( ( storeName == null ) ? 13 : storeName.hashCode() );
+        result = prime * result + ( ( storeType == null ) ? 17 : storeType.hashCode() );
+        return result;
+    }
+
+    @Override
+    public final boolean equals( final Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+        if ( obj == null )
+        {
+            return false;
+        }
+        if ( getClass() != obj.getClass() )
+        {
+            return false;
+        }
+        final EventStoreKey other = (EventStoreKey) obj;
+        if ( packageType == null )
+        {
+            if ( other.packageType != null )
+            {
+                return false;
+            }
+        }
+        else if ( !packageType.equals( other.packageType ) )
+        {
+            return false;
+        }
+        if ( storeName == null )
+        {
+            if ( other.storeName != null )
+            {
+                return false;
+            }
+        }
+        else if ( !storeName.equals( other.storeName ) )
+        {
+            return false;
+        }
+        if ( storeType == null )
+        {
+            return other.storeType == null;
+        }
+        return storeType.equals( other.storeType );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "%s:%s:%s", packageType, storeType, storeName );
+    }
+}

--- a/src/main/java/org/commonjava/event/store/IndyStoreErrorEvent.java
+++ b/src/main/java/org/commonjava/event/store/IndyStoreErrorEvent.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+public class IndyStoreErrorEvent
+{
+
+    private EventStoreKey storeKey;
+
+    private Throwable error;
+
+    public IndyStoreErrorEvent( EventStoreKey storeKey, Throwable error )
+    {
+        this.storeKey = storeKey;
+        this.error = error;
+    }
+
+    public EventStoreKey getStoreKey()
+    {
+        return storeKey;
+    }
+
+    public Throwable getError()
+    {
+        return error;
+    }
+
+}

--- a/src/main/java/org/commonjava/event/store/IndyStoreEvent.java
+++ b/src/main/java/org/commonjava/event/store/IndyStoreEvent.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Collection;
+
+/**
+ * Marker interface for events related to changes indy ArtifactStore instances.
+ */
+public interface IndyStoreEvent
+        extends Iterable<EventStoreKey>
+{
+
+    @JsonProperty("eventType")
+    StoreEventType getEventType();
+
+    @JsonProperty( "keys" )
+    Collection<EventStoreKey> getKeys();
+
+    @JsonProperty("eventMetadata")
+    EventMetadata getEventMetadata();
+
+}

--- a/src/main/java/org/commonjava/event/store/StoreEnablementEvent.java
+++ b/src/main/java/org/commonjava/event/store/StoreEnablementEvent.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 
+import static org.commonjava.event.store.StoreEventType.Enablement;
+
 public class StoreEnablementEvent
         implements IndyStoreEvent
 {
@@ -42,7 +44,8 @@ public class StoreEnablementEvent
     {
     }
 
-    public StoreEnablementEvent( EventMetadata eventMetadata, boolean preprocessing, boolean disabling, EventStoreKey... storeKeys )
+    public StoreEnablementEvent( EventMetadata eventMetadata, boolean preprocessing, boolean disabling,
+                                 EventStoreKey... storeKeys )
     {
         this.eventMetadata = eventMetadata;
         this.preprocessing = preprocessing;
@@ -66,7 +69,7 @@ public class StoreEnablementEvent
         return eventMetadata;
     }
 
-    @JsonSetter("eventMetadata")
+    @JsonSetter( "eventMetadata" )
     public void setEventMetadata( EventMetadata eventMetadata )
     {
         this.eventMetadata = eventMetadata;
@@ -75,7 +78,17 @@ public class StoreEnablementEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.Enablement;
+        return Enablement;
+    }
+
+    @JsonSetter( "eventType" )
+    public final void setEventType( StoreEventType eventType )
+    {
+        if ( Enablement != eventType )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Wrong event type! Should be %s but is %s", Enablement, eventType ) );
+        }
     }
 
     @Override
@@ -84,7 +97,7 @@ public class StoreEnablementEvent
         return storeKeys;
     }
 
-    @JsonSetter("keys")
+    @JsonSetter( "keys" )
     public void setKeys( Collection<EventStoreKey> keys )
     {
         this.storeKeys = new HashSet<>( keys );

--- a/src/main/java/org/commonjava/event/store/StoreEnablementEvent.java
+++ b/src/main/java/org/commonjava/event/store/StoreEnablementEvent.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+public class StoreEnablementEvent
+        implements IndyStoreEvent
+{
+
+    private EventMetadata eventMetadata;
+
+    private boolean disabling;
+
+    private Set<EventStoreKey> storeKeys;
+
+    private boolean preprocessing;
+
+    StoreEnablementEvent()
+    {
+    }
+
+    public StoreEnablementEvent( EventMetadata eventMetadata, boolean preprocessing, boolean disabling, EventStoreKey... storeKeys )
+    {
+        this.eventMetadata = eventMetadata;
+        this.preprocessing = preprocessing;
+        this.disabling = disabling;
+        this.storeKeys = new HashSet<>( Arrays.asList( storeKeys ) );
+    }
+
+    public boolean isDisabling()
+    {
+        return disabling;
+    }
+
+    public boolean isPreprocessing()
+    {
+        return preprocessing;
+    }
+
+    @Override
+    public EventMetadata getEventMetadata()
+    {
+        return eventMetadata;
+    }
+
+    @JsonSetter("eventMetadata")
+    public void setEventMetadata( EventMetadata eventMetadata )
+    {
+        this.eventMetadata = eventMetadata;
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.Enablement;
+    }
+
+    @Override
+    public Set<EventStoreKey> getKeys()
+    {
+        return storeKeys;
+    }
+
+    @JsonSetter("keys")
+    public void setKeys( Collection<EventStoreKey> keys )
+    {
+        this.storeKeys = new HashSet<>( keys );
+    }
+
+    @Override
+    public Iterator<EventStoreKey> iterator()
+    {
+        return storeKeys.iterator();
+    }
+
+    @Override
+    public void forEach( Consumer<? super EventStoreKey> action )
+    {
+        storeKeys.forEach( action );
+    }
+
+    @Override
+    public Spliterator<EventStoreKey> spliterator()
+    {
+        return storeKeys.spliterator();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ArtifactStoreEnablementEvent{ disabling=" + disabling + ", stores=" + storeKeys + ", preprocessing="
+                + preprocessing + '}';
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StoreEventType.java
+++ b/src/main/java/org/commonjava/event/store/StoreEventType.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+public enum StoreEventType
+{
+    PreDelete,
+    PostDelete,
+    Enablement,
+    PreRescan,
+    Rescan,
+    PostRescan,
+    PreUpdate,
+    PostUpdate
+}

--- a/src/main/java/org/commonjava/event/store/StorePostDeleteEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePostDeleteEvent.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Set;
+
+/**
+ * Event signaling the deletion of one or more ArtifactStore instances is COMPLETE. This event will always contain the same type of store, when there is
+ * more than one. Instance names are collected and available via getNames(), while the store type is available separately via the getType() method.
+ * <br/>
+ * As opposed to the ArtifactStore, this one MAY run asynchronously to avoid performance penalties for the user..
+ */
+public class StorePostDeleteEvent
+        extends AbstractIndyStoreEvent
+{
+    public StorePostDeleteEvent( final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                                 final @JsonProperty( "keys" ) Set<EventStoreKey> stores )
+    {
+        super( eventMetadata, stores );
+    }
+
+    @Override
+    public final StoreEventType getEventType()
+    {
+        return StoreEventType.PostDelete;
+    }
+
+    @JsonSetter( "eventType" )
+    public final void setEventType()
+    {
+
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "%s", getClass().getSimpleName() );
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StorePostDeleteEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePostDeleteEvent.java
@@ -21,6 +21,8 @@ import org.commonjava.event.common.EventMetadata;
 
 import java.util.Set;
 
+import static org.commonjava.event.store.StoreEventType.PostDelete;
+
 /**
  * Event signaling the deletion of one or more ArtifactStore instances is COMPLETE. This event will always contain the same type of store, when there is
  * more than one. Instance names are collected and available via getNames(), while the store type is available separately via the getType() method.
@@ -39,13 +41,13 @@ public class StorePostDeleteEvent
     @Override
     public final StoreEventType getEventType()
     {
-        return StoreEventType.PostDelete;
+        return PostDelete;
     }
 
     @JsonSetter( "eventType" )
-    public final void setEventType()
+    public final void setEventType( StoreEventType eventType )
     {
-
+        checkEventType( PostDelete, eventType );
     }
 
     @Override

--- a/src/main/java/org/commonjava/event/store/StorePostRescanEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePostRescanEvent.java
@@ -16,9 +16,13 @@
 package org.commonjava.event.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.commonjava.event.common.EventMetadata;
 
 import java.util.Collection;
+
+import static org.commonjava.event.store.StoreEventType.PostDelete;
+import static org.commonjava.event.store.StoreEventType.PostRescan;
 
 public class StorePostRescanEvent
         extends StoreRescanEvent
@@ -37,6 +41,12 @@ public class StorePostRescanEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.PostRescan;
+        return PostRescan;
+    }
+
+    @JsonSetter( "eventType" )
+    public void setEventType( StoreEventType eventType )
+    {
+        checkEventType( PostRescan, eventType );
     }
 }

--- a/src/main/java/org/commonjava/event/store/StorePostRescanEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePostRescanEvent.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Collection;
+
+public class StorePostRescanEvent
+        extends StoreRescanEvent
+{
+    public StorePostRescanEvent( final EventMetadata eventMetadata, final EventStoreKey storeKey )
+    {
+        super( eventMetadata, storeKey );
+    }
+
+    public StorePostRescanEvent( final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                                 final @JsonProperty( "keys" ) Collection<EventStoreKey> storeKeys )
+    {
+        super( eventMetadata, storeKeys );
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.PostRescan;
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StorePostUpdateEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePostUpdateEvent.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Map;
+
+/**
+ * Event signaling that one or more specified {@link EventStoreKey} instances' configurations were changed. The {@link StoreUpdateType}
+ * gives more information about the nature of the update.
+ * <br/>
+ * This event is fired <b>AFTER</b> the updated {@link EventStoreKey} is actually persisted.
+ * <br/>
+ * As opposed to the {@link StorePostUpdateEvent}, this one MAY run asynchronously to avoid performance penalties for the user..
+ */
+public class StorePostUpdateEvent
+        extends AbstractStoreUpdateEvent
+{
+
+    public StorePostUpdateEvent( final @JsonProperty( "updateType" ) StoreUpdateType type,
+                                 final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                                 final @JsonProperty( "changeMap" ) Map<EventStoreKey, EventStoreKey> changeMap )
+    {
+        super( type, eventMetadata, changeMap );
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.PostUpdate;
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StorePostUpdateEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePostUpdateEvent.java
@@ -16,9 +16,13 @@
 package org.commonjava.event.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.commonjava.event.common.EventMetadata;
 
+import java.util.List;
 import java.util.Map;
+
+import static org.commonjava.event.store.StoreEventType.PostUpdate;
 
 /**
  * Event signaling that one or more specified {@link EventStoreKey} instances' configurations were changed. The {@link StoreUpdateType}
@@ -34,7 +38,8 @@ public class StorePostUpdateEvent
 
     public StorePostUpdateEvent( final @JsonProperty( "updateType" ) StoreUpdateType type,
                                  final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
-                                 final @JsonProperty( "changeMap" ) Map<EventStoreKey, EventStoreKey> changeMap )
+                                 final @JsonProperty( "changeMap" )
+                                         Map<EventStoreKey, Map<String, List<Object>>> changeMap )
     {
         super( type, eventMetadata, changeMap );
     }
@@ -42,6 +47,12 @@ public class StorePostUpdateEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.PostUpdate;
+        return PostUpdate;
+    }
+
+    @JsonSetter( "eventType" )
+    public final void setEventType( StoreEventType eventType )
+    {
+        checkEventType( PostUpdate, eventType );
     }
 }

--- a/src/main/java/org/commonjava/event/store/StorePreDeleteEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePreDeleteEvent.java
@@ -21,6 +21,9 @@ import org.commonjava.event.common.EventMetadata;
 
 import java.util.Set;
 
+import static org.commonjava.event.store.StoreEventType.PreDelete;
+import static org.commonjava.event.store.StoreEventType.PreUpdate;
+
 /**
  * Event signaling the deletion of one or more ArtifactStore instances is ABOUT TO HAPPEN. This event will always contain a mapping of
  * affected stores to their root storage locations, available via {@link ()}.
@@ -38,13 +41,13 @@ public class StorePreDeleteEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.PreDelete;
+        return PreDelete;
     }
 
     @JsonSetter( "eventType" )
-    public final void setEventType()
+    public final void setEventType( StoreEventType eventType )
     {
-
+        checkEventType( PreDelete, eventType );
     }
 
     @Override

--- a/src/main/java/org/commonjava/event/store/StorePreDeleteEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePreDeleteEvent.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Set;
+
+/**
+ * Event signaling the deletion of one or more ArtifactStore instances is ABOUT TO HAPPEN. This event will always contain a mapping of
+ * affected stores to their root storage locations, available via {@link ()}.
+ */
+public class StorePreDeleteEvent
+        extends AbstractIndyStoreEvent
+{
+
+    public StorePreDeleteEvent( final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                                final @JsonProperty( "keys" ) Set<EventStoreKey> stores )
+    {
+        super( eventMetadata, stores );
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.PreDelete;
+    }
+
+    @JsonSetter( "eventType" )
+    public final void setEventType()
+    {
+
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "%s", getClass().getSimpleName() );
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StorePreRescanEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePreRescanEvent.java
@@ -16,9 +16,12 @@
 package org.commonjava.event.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.commonjava.event.common.EventMetadata;
 
 import java.util.Collection;
+
+import static org.commonjava.event.store.StoreEventType.PreRescan;
 
 public class StorePreRescanEvent
         extends StoreRescanEvent
@@ -37,6 +40,13 @@ public class StorePreRescanEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.PreRescan;
+        return PreRescan;
+    }
+
+    @JsonSetter( "eventType" )
+    @Override
+    public void setEventType( StoreEventType eventType )
+    {
+        checkEventType( PreRescan, eventType );
     }
 }

--- a/src/main/java/org/commonjava/event/store/StorePreRescanEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePreRescanEvent.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Collection;
+
+public class StorePreRescanEvent
+        extends StoreRescanEvent
+{
+    public StorePreRescanEvent( final EventMetadata eventMetadata, final EventStoreKey storeKey )
+    {
+        super( eventMetadata, storeKey );
+    }
+
+    public StorePreRescanEvent( final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                                final @JsonProperty( "keys" ) Collection<EventStoreKey> storeKeys )
+    {
+        super( eventMetadata, storeKeys );
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.PreRescan;
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StorePreUpdateEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePreUpdateEvent.java
@@ -16,9 +16,13 @@
 package org.commonjava.event.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.commonjava.event.common.EventMetadata;
 
+import java.util.List;
 import java.util.Map;
+
+import static org.commonjava.event.store.StoreEventType.PreUpdate;
 
 /**
  * Event signaling that one or more specified ArtifactStore instances' configurations were changed. The ArtifactStoreUpdateType
@@ -32,7 +36,8 @@ public class StorePreUpdateEvent
 
     public StorePreUpdateEvent( final @JsonProperty( "updateType" ) StoreUpdateType type,
                                 final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
-                                final @JsonProperty( "changeMap" ) Map<EventStoreKey, EventStoreKey> changeMap )
+                                final @JsonProperty( "changeMap" )
+                                        Map<EventStoreKey, Map<String, List<Object>>> changeMap )
     {
         super( type, eventMetadata, changeMap );
     }
@@ -40,6 +45,12 @@ public class StorePreUpdateEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.PreUpdate;
+        return PreUpdate;
+    }
+
+    @JsonSetter( "eventType" )
+    public final void setEventType( StoreEventType eventType )
+    {
+        checkEventType( PreUpdate, eventType );
     }
 }

--- a/src/main/java/org/commonjava/event/store/StorePreUpdateEvent.java
+++ b/src/main/java/org/commonjava/event/store/StorePreUpdateEvent.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Map;
+
+/**
+ * Event signaling that one or more specified ArtifactStore instances' configurations were changed. The ArtifactStoreUpdateType
+ * gives more information about the nature of the update.
+ * <br/>
+ * This event is fired <b>BEFORE</b> the updated ArtifactStore is actually persisted.
+ */
+public class StorePreUpdateEvent
+        extends AbstractStoreUpdateEvent
+{
+
+    public StorePreUpdateEvent( final @JsonProperty( "updateType" ) StoreUpdateType type,
+                                final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                                final @JsonProperty( "changeMap" ) Map<EventStoreKey, EventStoreKey> changeMap )
+    {
+        super( type, eventMetadata, changeMap );
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.PreUpdate;
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StoreRescanEvent.java
+++ b/src/main/java/org/commonjava/event/store/StoreRescanEvent.java
@@ -16,9 +16,12 @@
 package org.commonjava.event.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.commonjava.event.common.EventMetadata;
 
 import java.util.Collection;
+
+import static org.commonjava.event.store.StoreEventType.Rescan;
 
 /**
  * Event to signal that the rescanning of a particular artifact store has started.
@@ -41,6 +44,12 @@ public class StoreRescanEvent
     @Override
     public StoreEventType getEventType()
     {
-        return StoreEventType.Rescan;
+        return Rescan;
+    }
+
+    @JsonSetter( "eventType" )
+    public void setEventType( StoreEventType eventType )
+    {
+        checkEventType( Rescan, eventType );
     }
 }

--- a/src/main/java/org/commonjava/event/store/StoreRescanEvent.java
+++ b/src/main/java/org/commonjava/event/store/StoreRescanEvent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.event.common.EventMetadata;
+
+import java.util.Collection;
+
+/**
+ * Event to signal that the rescanning of a particular artifact store has started.
+ */
+public class StoreRescanEvent
+        extends AbstractIndyStoreEvent
+{
+
+    public StoreRescanEvent( final EventMetadata eventMetadata, final EventStoreKey store )
+    {
+        super( eventMetadata, store );
+    }
+
+    public StoreRescanEvent( final @JsonProperty( "eventMetadata" ) EventMetadata eventMetadata,
+                             final @JsonProperty( "keys" ) Collection<EventStoreKey> stores )
+    {
+        super( eventMetadata, stores );
+    }
+
+    @Override
+    public StoreEventType getEventType()
+    {
+        return StoreEventType.Rescan;
+    }
+}

--- a/src/main/java/org/commonjava/event/store/StoreUpdateType.java
+++ b/src/main/java/org/commonjava/event/store/StoreUpdateType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+/**
+ * Enumeration of the types of configuration updates that can happen for ArtifactStore's.
+ */
+public enum StoreUpdateType
+{
+
+    /** Definite creation of new store. */
+    ADD,
+    /** upadting an existing store. */
+    UPDATE
+
+}

--- a/src/main/java/org/commonjava/event/store/jackson/EventStoreKeyDeserializer.java
+++ b/src/main/java/org/commonjava/event/store/jackson/EventStoreKeyDeserializer.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.commonjava.event.store.EventStoreKey;
+
+import java.io.IOException;
+
+public final class EventStoreKeyDeserializer
+        extends StdDeserializer<EventStoreKey>
+{
+    private static final long serialVersionUID = 1L;
+
+    public EventStoreKeyDeserializer()
+    {
+        super( EventStoreKey.class );
+    }
+
+    @Override
+    public EventStoreKey deserialize( final JsonParser parser, final DeserializationContext context )
+            throws IOException
+    {
+        final String keyStr = parser.getText();
+        return EventStoreKey.fromString( keyStr );
+    }
+
+}

--- a/src/main/java/org/commonjava/event/store/jackson/EventStoreKeyModule.java
+++ b/src/main/java/org/commonjava/event/store/jackson/EventStoreKeyModule.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.commonjava.event.store.EventStoreKey;
+
+public class EventStoreKeyModule extends SimpleModule
+{
+
+    private static final long serialVersionUID = 1L;
+
+    public EventStoreKeyModule()
+    {
+        super( "Mock" );
+        addDeserializer( EventStoreKey.class, new EventStoreKeyDeserializer() );
+        addSerializer( EventStoreKey.class, new EventStoreKeySerializer() );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().getSimpleName().hashCode() + 17;
+    }
+
+    @Override
+    public boolean equals( final Object other )
+    {
+        if ( other == null )
+        {
+            return false;
+        }
+        return getClass().equals( other.getClass() );
+    }
+}

--- a/src/main/java/org/commonjava/event/store/jackson/EventStoreKeySerializer.java
+++ b/src/main/java/org/commonjava/event/store/jackson/EventStoreKeySerializer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.commonjava.event.store.EventStoreKey;
+
+import java.io.IOException;
+
+public final class EventStoreKeySerializer
+        extends StdSerializer<EventStoreKey>
+{
+    public EventStoreKeySerializer()
+    {
+        super( EventStoreKey.class );
+    }
+
+    @Override
+    public void serialize( final EventStoreKey key, final JsonGenerator generator,
+                           final SerializerProvider provider )
+            throws IOException
+    {
+        generator.writeString( key.toString() );
+    }
+}

--- a/src/test/java/org/commonjava/event/store/StoreEventTest.java
+++ b/src/test/java/org/commonjava/event/store/StoreEventTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,13 +23,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.commonjava.event.common.EventMetadata;
 import org.commonjava.event.store.jackson.EventStoreKeyModule;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.commonjava.event.store.EventStoreKey.fromString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,8 +45,27 @@ public class StoreEventTest
 {
     ObjectMapper mapper;
 
+    private final EventStoreKey key1 = new EventStoreKey( "maven", "group", "test1" );
+
+    private final EventStoreKey key2 = new EventStoreKey( "maven", "group", "test2" );
+
+    private final Set<EventStoreKey> keys = new HashSet<>();
+
     @BeforeEach
     public void prepare()
+    {
+        prepareObjMapper();
+        keys.add( key1 );
+        keys.add( key2 );
+    }
+
+    @AfterEach
+    public void clear()
+    {
+        keys.clear();
+    }
+
+    private void prepareObjMapper()
     {
         mapper = new ObjectMapper();
         mapper.setSerializationInclusion( JsonInclude.Include.NON_EMPTY );
@@ -56,53 +83,164 @@ public class StoreEventTest
     }
 
     @Test
-    public void testMarshall()
+    public void testMarshallForDeleteEvent()
             throws IOException
     {
-        final EventStoreKey key1 = new EventStoreKey( "maven", "group", "test1" );
-        final EventStoreKey key2 = new EventStoreKey( "maven", "group", "test2" );
-        final Set<EventStoreKey> keys = new HashSet<>();
-        keys.add( key1 );
-        keys.add( key2 );
-        final IndyStoreEvent event = new StorePostDeleteEvent( new EventMetadata(), keys );
-        String json = mapper.writeValueAsString( event );
+        final IndyStoreEvent postDelete = new StorePostDeleteEvent( new EventMetadata(), keys );
+        String json = mapper.writeValueAsString( postDelete );
         assertTrue( json.contains( "\"eventType\" : \"PostDelete\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
         assertTrue( json.contains( "maven:group:test1" ) );
         assertTrue( json.contains( "maven:group:test2" ) );
 
+        final IndyStoreEvent preDelete = new StorePreDeleteEvent( new EventMetadata(), keys );
+        json = mapper.writeValueAsString( preDelete );
+        assertTrue( json.contains( "\"eventType\" : \"PreDelete\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+        assertTrue( json.contains( "maven:group:test2" ) );
+
+    }
+
+    @Test
+    public void testMarshallForEnable()
+            throws IOException
+    {
         final IndyStoreEvent enableEvent = new StoreEnablementEvent( new EventMetadata(), true, true, key1, key2 );
-        json = mapper.writeValueAsString( enableEvent );
+        final String json = mapper.writeValueAsString( enableEvent );
         assertTrue( json.contains( "\"eventType\" : \"Enablement\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
         assertTrue( json.contains( "maven:group:test1" ) );
         assertTrue( json.contains( "maven:group:test2" ) );
     }
 
     @Test
-    public void testUnmarshall()
+    public void testMarshallForUpdate()
+            throws IOException
+    {
+        final IndyStoreEvent preCreate = new StorePreUpdateEvent( StoreUpdateType.ADD, new EventMetadata(),
+                                                                  singletonMap( key1, Collections.emptyMap() ) );
+        String json = mapper.writeValueAsString( preCreate );
+        assertTrue( json.contains( "\"eventType\" : \"PreUpdate\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
+        assertTrue( json.contains( "\"updateType\" : \"ADD\"" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+
+        final IndyStoreEvent preUpdate = new StorePreUpdateEvent( StoreUpdateType.UPDATE, new EventMetadata(),
+                                                                  singletonMap( key1, singletonMap( "description",
+                                                                                                    asList( "new Desc",
+                                                                                                            "old Desc" ) ) ) );
+        json = mapper.writeValueAsString( preUpdate );
+        assertTrue( json.contains( "\"eventType\" : \"PreUpdate\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
+        assertTrue( json.contains( "\"updateType\" : \"UPDATE\"" ) );
+        assertTrue( json.contains( "\"description\" : [ \"new Desc\", \"old Desc\" ]" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+
+        final IndyStoreEvent postCreate = new StorePostUpdateEvent( StoreUpdateType.ADD, new EventMetadata(),
+                                                                    singletonMap( key1, Collections.emptyMap() ) );
+        json = mapper.writeValueAsString( postCreate );
+        assertTrue( json.contains( "\"eventType\" : \"PostUpdate\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
+        assertTrue( json.contains( "\"updateType\" : \"ADD\"" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+
+        final IndyStoreEvent postUpdate = new StorePostUpdateEvent( StoreUpdateType.UPDATE, new EventMetadata(),
+                                                                    singletonMap( key1, singletonMap( "description",
+                                                                                                      asList( "new Desc",
+                                                                                                              "old Desc" ) ) ) );
+        json = mapper.writeValueAsString( postUpdate );
+        assertTrue( json.contains( "\"eventType\" : \"PostUpdate\"" ) );
+        assertTrue( json.contains( "eventMetadata" ) );
+        assertTrue( json.contains( "\"updateType\" : \"UPDATE\"" ) );
+        assertTrue( json.contains( "\"description\" : [ \"new Desc\", \"old Desc\" ]" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+    }
+
+    @Test
+    public void testUnmarshallForDelete()
             throws Exception
     {
         String json =
-                "{\"eventType\" : \"PostDelete\", \n \"keys\" : [ \"maven:group:test1\", \"maven:group:test2\" ]\n"
-                        + "}";
+                "{\"eventType\" : \"PostDelete\", \"keys\" : [ \"maven:group:test1\", \"maven:group:test2\" ]" + "}";
         StorePostDeleteEvent postDelete = mapper.readValue( json, StorePostDeleteEvent.class );
         assertSame( StoreEventType.PostDelete, postDelete.getEventType() );
-        assertTrue( postDelete.getKeys().contains( EventStoreKey.fromString( "maven:group:test1" ) ) );
-        assertTrue( postDelete.getKeys().contains( EventStoreKey.fromString( "maven:group:test2" ) ) );
+        assertTrue( postDelete.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( postDelete.getKeys().contains( fromString( "maven:group:test2" ) ) );
 
-        json =
+        json = "{\"eventType\" : \"PreDelete\",  \"keys\" : [ \"maven:group:test1\", \"maven:group:test2\" ]" + "}";
+        StorePreDeleteEvent preDelete = mapper.readValue( json, StorePreDeleteEvent.class );
+        assertSame( StoreEventType.PreDelete, preDelete.getEventType() );
+        assertTrue( preDelete.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( preDelete.getKeys().contains( fromString( "maven:group:test2" ) ) );
+    }
+
+    @Test
+    public void testUnmarshallForEnablement()
+            throws IOException
+    {
+        String json =
                 "{\"disabling\" : true,\"preprocessing\" : true,\"keys\" : [ \"maven:group:test1\", \"maven:group:test2\" ],\"eventType\" : \"Enablement\"}";
         StoreEnablementEvent enablement = mapper.readValue( json, StoreEnablementEvent.class );
         assertSame( StoreEventType.Enablement, enablement.getEventType() );
-        assertTrue( enablement.getKeys().contains( EventStoreKey.fromString( "maven:group:test1" ) ) );
-        assertTrue( enablement.getKeys().contains( EventStoreKey.fromString( "maven:group:test2" ) ) );
+        assertTrue( enablement.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( enablement.getKeys().contains( fromString( "maven:group:test2" ) ) );
         assertTrue( enablement.isDisabling() );
         assertTrue( enablement.isPreprocessing() );
     }
 
     @Test
-    public void test() throws Exception{
-        EventStoreKey key = EventStoreKey.fromString( "maven:group:test1" );
-        System.out.println( mapper.writeValueAsString(new StoreEnablementEvent( null,true, false, key )));
+    public void testUnmarshallForUpdate()
+            throws IOException
+    {
+        String json =
+                "{\"eventType\" : \"PreUpdate\", \"updateType\": \"ADD\",  \"keys\" : [ \"maven:group:test1\" ], \"eventMetadata\" : {"
+                        + "\"pacakgeType\" : \"maven\"" + "  }," + "  \"changeMap\" : {" + "\"maven:group:test1\" : {}"
+                        + "}}";
+        StorePreUpdateEvent preCreate = mapper.readValue( json, StorePreUpdateEvent.class );
+        assertSame( StoreEventType.PreUpdate, preCreate.getEventType() );
+        assertSame( StoreUpdateType.ADD, preCreate.getType() );
+        assertTrue( preCreate.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( preCreate.getChangeMap().containsKey( key1 ) );
+
+        json =
+                "{\"eventType\" : \"PreUpdate\", \"updateType\": \"UPDATE\",  \"keys\" : [ \"maven:group:test1\" ], \"eventMetadata\" : {"
+                        + "\"pacakgeType\" : \"maven\"" + "  }," + "  \"changeMap\" : {" + "\"maven:group:test1\" : {"
+                        + "\"description\" : [ \"new Desc\", \"old Desc\" ]" + "}" + "  }}";
+        StorePreUpdateEvent preUpdate = mapper.readValue( json, StorePreUpdateEvent.class );
+        assertSame( StoreEventType.PreUpdate, preUpdate.getEventType() );
+        assertSame( StoreUpdateType.UPDATE, preUpdate.getType() );
+        assertTrue( preUpdate.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( preUpdate.getChangeMap().containsKey( key1 ) );
+        Map<String, List<Object>> changes = preUpdate.getChangeMap().get( key1 );
+        assertTrue( changes.containsKey( "description" ) );
+        assertEquals( "new Desc", changes.get( "description" ).get( 0 ) );
+        assertEquals( "old Desc", changes.get( "description" ).get( 1 ) );
+
+        json =
+                "{\"eventType\" : \"PostUpdate\", \"updateType\": \"ADD\",  \"keys\" : [ \"maven:group:test1\" ], \"eventMetadata\" : {"
+                        + "\"pacakgeType\" : \"maven\"" + "  }," + "  \"changeMap\" : {" + "\"maven:group:test1\" : {}"
+                        + "}}";
+        StorePostUpdateEvent postCreate = mapper.readValue( json, StorePostUpdateEvent.class );
+        assertSame( StoreEventType.PostUpdate, postCreate.getEventType() );
+        assertSame( StoreUpdateType.ADD, postCreate.getType() );
+        assertTrue( postCreate.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( postCreate.getChangeMap().containsKey( key1 ) );
+
+        json =
+                "{\"eventType\" : \"PostUpdate\", \"updateType\": \"UPDATE\",  \"keys\" : [ \"maven:group:test1\" ], \"eventMetadata\" : {"
+                        + "\"pacakgeType\" : \"maven\"" + "  }," + "  \"changeMap\" : {" + "\"maven:group:test1\" : {"
+                        + "\"description\" : [ \"new Desc\", \"old Desc\" ]" + "}" + "  }}";
+        StorePostUpdateEvent postUpdate = mapper.readValue( json, StorePostUpdateEvent.class );
+        assertSame( StoreEventType.PostUpdate, postUpdate.getEventType() );
+        assertSame( StoreUpdateType.UPDATE, postUpdate.getType() );
+        assertTrue( postUpdate.getKeys().contains( fromString( "maven:group:test1" ) ) );
+        assertTrue( postUpdate.getChangeMap().containsKey( key1 ) );
+        changes = postUpdate.getChangeMap().get( key1 );
+        assertTrue( changes.containsKey( "description" ) );
+        assertEquals( "new Desc", changes.get( "description" ).get( 0 ) );
+        assertEquals( "old Desc", changes.get( "description" ).get( 1 ) );
+
     }
 
 }

--- a/src/test/java/org/commonjava/event/store/StoreEventTest.java
+++ b/src/test/java/org/commonjava/event/store/StoreEventTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.event.store;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.commonjava.event.common.EventMetadata;
+import org.commonjava.event.store.jackson.EventStoreKeyModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StoreEventTest
+{
+    ObjectMapper mapper;
+
+    @BeforeEach
+    public void prepare()
+    {
+        mapper = new ObjectMapper();
+        mapper.setSerializationInclusion( JsonInclude.Include.NON_EMPTY );
+        mapper.configure( JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, true );
+        mapper.configure( DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true );
+
+        mapper.enable( SerializationFeature.INDENT_OUTPUT, SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID );
+        mapper.enable( MapperFeature.AUTO_DETECT_FIELDS );
+
+        mapper.disable( SerializationFeature.WRITE_NULL_MAP_VALUES, SerializationFeature.WRITE_EMPTY_JSON_ARRAYS );
+        mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
+        mapper.disable( DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES );
+        mapper.registerModule( new EventStoreKeyModule() );
+        mapper.registerSubtypes( EventStoreKey.class );
+    }
+
+    @Test
+    public void testMarshall()
+            throws IOException
+    {
+        final EventStoreKey key1 = new EventStoreKey( "maven", "group", "test1" );
+        final EventStoreKey key2 = new EventStoreKey( "maven", "group", "test2" );
+        final Set<EventStoreKey> keys = new HashSet<>();
+        keys.add( key1 );
+        keys.add( key2 );
+        final IndyStoreEvent event = new StorePostDeleteEvent( new EventMetadata(), keys );
+        String json = mapper.writeValueAsString( event );
+        assertTrue( json.contains( "\"eventType\" : \"PostDelete\"" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+        assertTrue( json.contains( "maven:group:test2" ) );
+
+        final IndyStoreEvent enableEvent = new StoreEnablementEvent( new EventMetadata(), true, true, key1, key2 );
+        json = mapper.writeValueAsString( enableEvent );
+        assertTrue( json.contains( "\"eventType\" : \"Enablement\"" ) );
+        assertTrue( json.contains( "maven:group:test1" ) );
+        assertTrue( json.contains( "maven:group:test2" ) );
+    }
+
+    @Test
+    public void testUnmarshall()
+            throws Exception
+    {
+        String json =
+                "{\"eventType\" : \"PostDelete\", \n \"keys\" : [ \"maven:group:test1\", \"maven:group:test2\" ]\n"
+                        + "}";
+        StorePostDeleteEvent postDelete = mapper.readValue( json, StorePostDeleteEvent.class );
+        assertSame( StoreEventType.PostDelete, postDelete.getEventType() );
+        assertTrue( postDelete.getKeys().contains( EventStoreKey.fromString( "maven:group:test1" ) ) );
+        assertTrue( postDelete.getKeys().contains( EventStoreKey.fromString( "maven:group:test2" ) ) );
+
+        json =
+                "{\"disabling\" : true,\"preprocessing\" : true,\"keys\" : [ \"maven:group:test1\", \"maven:group:test2\" ],\"eventType\" : \"Enablement\"}";
+        StoreEnablementEvent enablement = mapper.readValue( json, StoreEnablementEvent.class );
+        assertSame( StoreEventType.Enablement, enablement.getEventType() );
+        assertTrue( enablement.getKeys().contains( EventStoreKey.fromString( "maven:group:test1" ) ) );
+        assertTrue( enablement.getKeys().contains( EventStoreKey.fromString( "maven:group:test2" ) ) );
+        assertTrue( enablement.isDisabling() );
+        assertTrue( enablement.isPreprocessing() );
+    }
+
+    @Test
+    public void test() throws Exception{
+        EventStoreKey key = EventStoreKey.fromString( "maven:group:test1" );
+        System.out.println( mapper.writeValueAsString(new StoreEnablementEvent( null,true, false, key )));
+    }
+
+}


### PR DESCRIPTION
I did some simplification for the store event model classes (comared with legacy indy store event classes):

- Simplify the ArtifactStore class usage to EventStoreKey( Derived from StoreKey) for two reasons: 1. Avoid to include the whole ArtifactStore models into the indy-event-model project. 2. reduce the whole payload
- ~~Remove the EventMetadata usage in the store event models: I found nearly all usage of store event model in legacy indy does not use this EventMetadata class for further action, so I'm thinking we should remove this to reduce the payload~~
- Add an "eventType" field to make the consumer to know which event type to listen to.

@jdcasey  @sswguo @ruhan1 let's discuss if this model is suitable for later usage in event handler system.