### PR TITLE
Update atlas-version to 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,11 @@
 
   <properties>
     <projectEmail>https://github.com/Commonjava/indy-model</projectEmail>
-    <atlas-version>1.1.1</atlas-version>
+    <atlas-version>1.1.3</atlas-version>
     <logback-version>1.2.12</logback-version>
     <jackson-version>2.15.2</jackson-version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This will update ch.qos.logback version and get rid of critical vulnerabilities in downstream projects.