### PR TITLE
Upgrade Atlas to 1.1.9 and add NPM model classes

### DIFF
--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/content/PackagePath.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/content/PackagePath.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import java.util.Optional;
+
+import static org.commonjava.indy.util.PathUtils.normalize;
+
+public class PackagePath
+{
+
+    private String tarPath;
+
+    private Boolean scoped;
+
+    private String packageName;
+
+    private String version;
+
+    private String scopedName;
+
+    public PackagePath(String tarPath )
+    {
+        this.tarPath = tarPath;
+        init();
+    }
+
+    private void init()
+    {
+        String[] pathParts = tarPath.split( "/" );
+        if ( tarPath.startsWith( "@" ) )
+        {
+            scoped = Boolean.TRUE;
+            scopedName = pathParts[0];
+            packageName = pathParts[1];
+            if ( pathParts.length == 4 && "-".equals( pathParts[2] ) )
+            {
+                String tarName = pathParts[3];
+                version = tarName.substring( packageName.length() + 1, tarName.length() - 4 );
+            }
+            else if ( pathParts.length == 3 )
+            {
+                version = pathParts[2];
+            }
+        }
+        else
+        {
+            scoped = Boolean.FALSE;
+            packageName = pathParts[0];
+            if ( pathParts.length == 3 && "-".equals( pathParts[1] ) )
+            {
+                String tarName = pathParts[2];
+                version = tarName.substring( packageName.length() + 1, tarName.length() - 4 );
+            }
+            else if ( pathParts.length == 2 )
+            {
+                version = pathParts[1];
+            }
+        }
+    }
+
+    public String getTarPath()
+    {
+        return tarPath;
+    }
+
+    public void setTarPath( String tarPath )
+    {
+        this.tarPath = tarPath;
+    }
+
+    public Boolean isScoped()
+    {
+        return scoped;
+    }
+
+    public void setScoped( Boolean scoped )
+    {
+        this.scoped = scoped;
+    }
+
+    public String getPackageName()
+    {
+        return packageName;
+    }
+
+    public void setPackageName( String packageName )
+    {
+        this.packageName = packageName;
+    }
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+    public void setVersion( String version )
+    {
+        this.version = version;
+    }
+
+    public String getScopedName()
+    {
+        return scopedName;
+    }
+
+    public void setScopedName( String scopedName )
+    {
+        this.scopedName = scopedName;
+    }
+
+    public String getVersionPath()
+    {
+        return isScoped() ? normalize( scopedName, packageName, version ) : normalize( packageName, version );
+    }
+
+    public static Optional<PackagePath> parse( final String tarPath )
+    {
+        String path = tarPath;
+        if ( path.startsWith( "/" ) )
+        {
+            path = path.substring( 1 );
+        }
+        String[] parts = path.split( "/" );
+        if ( parts.length < 2 )
+        {
+            return Optional.empty();
+        }
+        else if ( path.startsWith( "@" ) && parts.length < 3 )
+        {
+            return Optional.empty();
+        }
+        PackagePath packagePath = new PackagePath( path );
+        return Optional.of( packagePath );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PackagePath{" + "tarPath='" + tarPath + '\'' + ", scoped=" + scoped + ", packageName='"
+                        + packageName + '\'' + ", version='" + version + '\'' + ", scopedName='" + scopedName + '\''
+                        + '}';
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Bugs.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Bugs.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+public class Bugs
+{
+
+    private final String url;
+
+    private final String email;
+
+    protected Bugs()
+    {
+        this.url = null;
+        this.email = null;
+    }
+
+    public Bugs( final String url )
+    {
+        this.url = url;
+        this.email = null;
+    }
+
+    public Bugs( final String url, final String email )
+    {
+        this.url = url;
+        this.email = email;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+    public String getEmail()
+    {
+        return email;
+    }
+
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Commitplease.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Commitplease.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import java.util.List;
+
+public class Commitplease
+{
+
+    private final Boolean nohook;
+
+    private final List<String> components;
+
+    private final String markerPattern;
+
+    private final String ticketPattern;
+
+    protected Commitplease()
+    {
+        this.nohook = null;
+        this.components = null;
+        this.markerPattern = null;
+        this.ticketPattern = null;
+    }
+
+    public Commitplease( final Boolean nohook, final List<String> components, final String markerPattern,
+                         final String ticketPattern )
+    {
+        this.nohook = nohook;
+        this.components = components;
+        this.markerPattern = markerPattern;
+        this.ticketPattern = ticketPattern;
+    }
+
+    public Boolean getNohook()
+    {
+        return nohook;
+    }
+
+    public List<String> getComponents()
+    {
+        return components;
+    }
+
+    public String getMarkerPattern()
+    {
+        return markerPattern;
+    }
+
+    public String getTicketPattern()
+    {
+        return ticketPattern;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Directories.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Directories.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Directories
+{
+    private static final String LIB = "lib";
+
+    private static final String BIN = "bin";
+
+    private static final String MAN = "man";
+
+    private static final String DOC = "doc";
+
+    private static final String EXAMPLE = "example";
+
+    private static final String TEST = "test";
+
+    private Map<String, String> directoriesMap = new HashMap<String, String>();
+
+    protected Directories()
+    {
+    }
+
+    public String getLib()
+    {
+        return directoriesMap.get( LIB );
+    }
+
+    public void setLib( String lib )
+    {
+        directoriesMap.put( LIB, lib );
+    }
+
+    public String getBin()
+    {
+        return directoriesMap.get( BIN );
+    }
+
+    public void setBin( String bin )
+    {
+        directoriesMap.put( BIN, bin );
+    }
+
+    public String getMan()
+    {
+        return directoriesMap.get( MAN );
+    }
+
+    public void setMan( String man )
+    {
+        directoriesMap.put( MAN, man );
+    }
+
+    public String getDoc()
+    {
+        return directoriesMap.get( DOC );
+    }
+
+    public void setDoc( String doc )
+    {
+        directoriesMap.put( DOC, doc );
+    }
+
+    public String getExample()
+    {
+        return directoriesMap.get( EXAMPLE );
+    }
+
+    public void setExample( String example )
+    {
+        directoriesMap.put( EXAMPLE, example );
+    }
+
+    public String getTest()
+    {
+        return directoriesMap.get( TEST );
+    }
+
+    public void setTest( String test )
+    {
+        directoriesMap.put( TEST, test );
+    }
+
+    public Map<String, String> fetchDirectoriesMap()
+    {
+        return directoriesMap;
+    }
+
+    public String getDirectory( String name )
+    {
+        return directoriesMap.get( name );
+    }
+
+    public void putDirectory( String name, String value )
+    {
+        directoriesMap.put( name, value );
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Dist.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Dist.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+public class Dist
+{
+
+    private final String shasum;
+
+    private final String tarball;
+
+    protected Dist()
+    {
+        this.shasum = null;
+        this.tarball = null;
+    }
+
+    public Dist( final String shasum, final String tarball )
+    {
+        this.shasum = shasum;
+        this.tarball = tarball;
+    }
+
+    public String getShasum()
+    {
+        return shasum;
+    }
+
+    public String getTarball()
+    {
+        return tarball;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/DistTag.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/DistTag.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DistTag
+{
+    public static final String LATEST = "latest";
+
+    public static final String STABLE = "stable";
+
+    public static final String BETA = "beta";
+
+    public static final String DEV = "dev";
+
+    private static final String CANARY = "canary";
+
+    private Map<String, String> tagsMap = new HashMap<String, String>();
+
+    public DistTag()
+    {
+    }
+
+    public String getLatest() {
+        return tagsMap.get(LATEST);
+    }
+
+    public void setLatest(String latest) {
+        tagsMap.put(LATEST, latest);
+    }
+
+    public String getStable() {
+        return tagsMap.get(STABLE);
+    }
+
+    public void setStable(String stable) {
+        tagsMap.put(STABLE,stable);
+    }
+
+    public String getBeta() {
+        return tagsMap.get(BETA);
+    }
+
+    public void setBeta(String beta) {
+        tagsMap.put(BETA,beta);
+    }
+
+    public String getDev() {
+        return tagsMap.get(DEV);
+    }
+
+    public void setDev(String dev) {
+        tagsMap.put(DEV,dev);
+    }
+
+    public String getCanary()
+    {
+        return tagsMap.get( CANARY );
+    }
+
+    public void setCanary( String canary )
+    {
+        tagsMap.put( CANARY, canary );
+    }
+
+    public Map<String, String> fetchTagsMap()
+    {
+        return tagsMap;
+    }
+
+    public String getTag(String tag) {
+        return tagsMap.get(tag);
+    }
+
+    public void putTag(String tag, String value) {
+        tagsMap.put(tag, value);
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Engines.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Engines.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Engines
+{
+
+    private static final String NODE = "node";
+
+    private static final String NPM = "npm";
+
+    private Map<String, String> enginesMap = new HashMap<String, String>();
+
+    protected Engines()
+    {
+    }
+
+    protected Engines( String engine )
+    {
+        String[] strings = engine.split( String.valueOf( Character.SPACE_SEPARATOR ) );
+
+        if ( strings.length != 2  )
+        {
+            return;
+        }
+
+        if ( NPM.equals( strings[0] ) )
+        {
+            enginesMap.put( NPM, strings[1] );
+        }
+        else if ( NODE.equals( strings[0] ) )
+        {
+            enginesMap.put( NODE, strings[1] );
+        }
+    }
+
+    public String getNode()
+    {
+        return enginesMap.get( NODE );
+    }
+
+    public void setNode( String node )
+    {
+        enginesMap.put( NODE, node );
+    }
+
+    public String getNpm()
+    {
+        return enginesMap.get( NPM );
+    }
+
+    public void setNpm( String npm )
+    {
+        enginesMap.put( NPM, npm );
+    }
+
+    public Map<String, String> fetchEnginesMap()
+    {
+        return enginesMap;
+    }
+
+    public String getEngine( String name )
+    {
+        return enginesMap.get( name );
+    }
+
+    public void putEngine( String name, String value )
+    {
+        enginesMap.put( name, value );
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/License.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/License.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+public class License
+{
+    private final String type;
+
+    private final String url;
+
+    protected License()
+    {
+        this.type = null;
+        this.url = null;
+    }
+
+    public License( final String type )
+    {
+        this.type = type;
+        this.url = null;
+    }
+
+    public License( final String type, final String url )
+    {
+        this.type = type;
+        this.url = url;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmJsonOpts.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmJsonOpts.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import java.util.List;
+
+public class NpmJsonOpts
+{
+
+    private final String file;
+
+    private final Boolean wscript;
+
+    private final List<String> contributors;
+
+    private final Boolean serverjs;
+
+    protected NpmJsonOpts()
+    {
+        this.file = null;
+        this.wscript = null;
+        this.contributors = null;
+        this.serverjs = null;
+    }
+
+    public NpmJsonOpts( final String file, final Boolean wscript, final List<String> contributors, final Boolean serverjs )
+    {
+        this.file = file;
+        this.wscript = wscript;
+        this.contributors = contributors;
+        this.serverjs = serverjs;
+    }
+
+    public String getFile()
+    {
+        return file;
+    }
+
+    public Boolean getWscript()
+    {
+        return wscript;
+    }
+
+    public List<String> getContributors()
+    {
+        return contributors;
+    }
+
+    public Boolean getServerjs()
+    {
+        return serverjs;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmOperationalInternal.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmOperationalInternal.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+public class NpmOperationalInternal
+{
+
+    private final String host;
+
+    private final String tmp;
+
+    protected NpmOperationalInternal()
+    {
+        this.host = null;
+        this.tmp = null;
+    }
+
+    public NpmOperationalInternal( final String host, final String tmp )
+    {
+        this.host = host;
+        this.tmp = tmp;
+    }
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public String getTmp()
+    {
+        return tmp;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/PackageMetadata.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/PackageMetadata.java
@@ -1,0 +1,447 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.atlas.maven.ident.util.VersionUtils;
+import org.commonjava.atlas.maven.ident.version.SingleVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+@JsonIgnoreProperties( { "_id", "_rev", "_attachments" } )
+public class PackageMetadata
+                implements Serializable, Comparable<PackageMetadata>
+{
+    private static final long serialVersionUID = 1L;
+
+    private static final String TIMEOUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
+    private static final String MODIFIED = "modified";
+
+    private static final String CREATED = "created";
+
+    private String name;
+
+    private String description;
+
+    @JsonProperty( "dist-tags" )
+    private DistTag distTags = new DistTag();
+
+    private Map<String, VersionMetadata> versions = new LinkedHashMap<>();
+
+    private List<UserInfo> maintainers = new ArrayList<>();
+
+    private Map<String, String> time = new LinkedHashMap<>();
+
+    private UserInfo author;
+
+    private Map<String, Boolean> users = new LinkedHashMap<>();
+
+    private Repository repository;
+
+    private String readme;
+
+    private String readmeFilename;
+
+    private String homepage;
+
+    private List<String> keywords = new ArrayList<>();
+
+    private Bugs bugs;
+
+    private License license;
+
+    public PackageMetadata()
+    {
+    }
+
+    public PackageMetadata( String name )
+    {
+        this.name = name;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName( String name )
+    {
+        this.name = name;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription( String description )
+    {
+        this.description = description;
+    }
+
+    public DistTag getDistTags()
+    {
+        return distTags;
+    }
+
+    public void setDistTags( DistTag distTags )
+    {
+        this.distTags = distTags;
+    }
+
+    public Map<String, VersionMetadata> getVersions()
+    {
+        return versions;
+    }
+
+    public void setVersions( Map<String, VersionMetadata> versions )
+    {
+        this.versions = versions;
+    }
+
+    public List<UserInfo> getMaintainers()
+    {
+        return maintainers;
+    }
+
+    public void setMaintainers( List<UserInfo> maintainers )
+    {
+        this.maintainers = maintainers;
+    }
+
+    public Map<String, String> getTime()
+    {
+        return time;
+    }
+
+    public void setTime( Map<String, String> time )
+    {
+        this.time = time;
+    }
+
+    public UserInfo getAuthor()
+    {
+        return author;
+    }
+
+    public void setAuthor( UserInfo author )
+    {
+        this.author = author;
+    }
+
+    public Map<String, Boolean> getUsers()
+    {
+        return users;
+    }
+
+    public void setUsers( Map<String, Boolean> users )
+    {
+        this.users = users;
+    }
+
+    public Repository getRepository()
+    {
+        return repository;
+    }
+
+    public void setRepository( Repository repository )
+    {
+        this.repository = repository;
+    }
+
+    public String getReadme()
+    {
+        return readme;
+    }
+
+    public void setReadme( String readme )
+    {
+        this.readme = readme;
+    }
+
+    public String getReadmeFilename()
+    {
+        return readmeFilename;
+    }
+
+    public void setReadmeFilename( String readmeFilename )
+    {
+        this.readmeFilename = readmeFilename;
+    }
+
+    public String getHomepage()
+    {
+        return homepage;
+    }
+
+    public void setHomepage( String homepage )
+    {
+        this.homepage = homepage;
+    }
+
+    public List<String> getKeywords()
+    {
+        return keywords;
+    }
+
+    public void setKeywords( List<String> keywords )
+    {
+        this.keywords = keywords;
+    }
+
+    public Bugs getBugs()
+    {
+        return bugs;
+    }
+
+    public void setBugs( Bugs bugs )
+    {
+        this.bugs = bugs;
+    }
+
+    public License getLicense()
+    {
+        return license;
+    }
+
+    public void setLicense( License license )
+    {
+        this.license = license;
+    }
+
+    public void addMaintainers( UserInfo userInfo )
+    {
+        this.getMaintainers().add( userInfo );
+    }
+
+    public void addKeywords( String key )
+    {
+        this.getKeywords().add( key );
+    }
+
+    @Override
+    public int compareTo( PackageMetadata o )
+    {
+        return 0;
+    }
+
+    public boolean merge( PackageMetadata source, boolean isForGroup )
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+
+        boolean changed = false;
+        if ( source.getName() != null )
+        {
+            this.setName( source.getName() );
+            changed = true;
+        }
+        if ( source.getDescription() != null )
+        {
+            this.setDescription( source.getDescription() );
+            changed = true;
+        }
+        if ( source.getAuthor() != null )
+        {
+            this.setAuthor( source.getAuthor() );
+            changed = true;
+        }
+        if ( source.getRepository() != null )
+        {
+            this.setRepository( source.getRepository() );
+            changed = true;
+        }
+        if ( source.getReadme() != null )
+        {
+            this.setReadme( source.getReadme() );
+            changed = true;
+        }
+        if ( source.getReadmeFilename() != null )
+        {
+            this.setReadmeFilename( source.getReadmeFilename() );
+            changed = true;
+        }
+        if ( source.getHomepage() != null )
+        {
+            this.setHomepage( source.getHomepage() );
+            changed = true;
+        }
+        if ( source.getBugs() != null )
+        {
+            this.setBugs( source.getBugs() );
+            changed = true;
+        }
+        if ( source.getLicense() != null )
+        {
+            this.setLicense( source.getLicense() );
+            changed = true;
+        }
+
+        // merge maintainers list
+        for ( UserInfo m : source.getMaintainers() )
+        {
+            if ( m.getName() != null && !maintainers.contains( m ) )
+            {
+                this.addMaintainers( new UserInfo( m.getName(), m.getEmail(), m.getUrl() ) );
+                changed = true;
+            }
+        }
+
+        // merge keywords list
+        for ( String key : source.getKeywords() )
+        {
+            if ( !keywords.contains( key ) )
+            {
+                this.addKeywords( key );
+                changed = true;
+            }
+        }
+
+        // merge users map
+        Map<String, Boolean> sourceUsers = source.getUsers();
+        for ( final String user : sourceUsers.keySet() )
+        {
+            if ( users.containsKey( user ) && users.get( user ).equals( sourceUsers.get( user ) ) )
+            {
+                continue;
+            }
+            users.put( user, sourceUsers.get( user ) );
+            changed = true;
+        }
+
+        // merge time map
+        SimpleDateFormat sdf = new SimpleDateFormat( TIMEOUT_FORMAT );
+        Map<String, Date> clone = new LinkedHashMap<>();
+
+        for ( final String key : time.keySet() )
+        {
+            String value = time.get( key );
+            Date date = null;
+            try
+            {
+                date = sdf.parse( value );
+            }
+            catch ( ParseException e )
+            {
+                logger.error( String.format( "Cannot parse date: %s. Reason: %s", value, e ) );
+            }
+            clone.put( key, date );
+        }
+
+        Map<String, String> sourceTimes = source.getTime();
+        boolean added = false;
+        for ( final String key : sourceTimes.keySet() )
+        {
+            String value = sourceTimes.get( key );
+            Date date;
+            try
+            {
+                date = sdf.parse( value );
+            }
+            catch ( ParseException e )
+            {
+                logger.error( String.format( "Cannot parse date: %s. Reason: %s", value, e ) );
+                continue;
+            }
+
+            // if source's version update time is more recent(sort as the letter order), will update it into the original map.
+            if ( clone.containsKey( key ) && date.compareTo( clone.get( key ) ) <= 0 )
+            {
+                continue;
+            }
+            clone.put( key, date );
+            added = true;
+            changed = true;
+        }
+
+        // only sorting the map when update occurred
+        if ( added )
+        {
+            // sort as the time value in map
+            List<Map.Entry<String, Date>> timeList = new ArrayList<>( clone.entrySet() );
+            // sort the time as value (update time) asc
+            timeList.sort( Map.Entry.comparingByValue() );
+
+            Map<String, String> result = new LinkedHashMap<>();
+            // make the 'modified' and 'created' value as the first two keys in final map
+            if ( clone.get( MODIFIED ) != null )
+            {
+                result.put( MODIFIED, sdf.format( clone.get( MODIFIED ) ) );
+            }
+            if ( clone.get( CREATED ) != null )
+            {
+                result.put( CREATED, sdf.format( clone.get( CREATED ) ) );
+            }
+
+            for ( final Map.Entry<String, Date> entry : timeList )
+            {
+                if ( MODIFIED.equals( entry.getKey() ) || CREATED.equals( entry.getKey() ) )
+                {
+                    continue;
+                }
+                result.put( entry.getKey(), sdf.format( entry.getValue() ) );
+            }
+            time = result;
+        }
+
+        // merge dist-tag object
+        DistTag sourceDist = source.getDistTags();
+        Map<String, String> sourceDistMap = sourceDist.fetchTagsMap();
+        Map<String, String> thisDistMap = distTags.fetchTagsMap();
+        if ( thisDistMap.isEmpty() && !sourceDistMap.isEmpty() )
+        {
+            this.setDistTags( sourceDist );
+            changed = true;
+        }
+        else
+        {
+            for ( final String tag : sourceDistMap.keySet() )
+            {
+                SingleVersion sourceVersion = VersionUtils.createSingleVersion( sourceDistMap.get( tag ) );
+                SingleVersion thisVersion = VersionUtils.createSingleVersion( thisDistMap.get( tag ) );
+                if ( thisDistMap.containsKey( tag ) && sourceVersion.compareTo( thisVersion ) <= 0 )
+                {
+                    continue;
+                }
+                distTags.putTag( tag, sourceDistMap.get( tag ) );
+                changed = true;
+            }
+        }
+
+        //merge versions, keep the first version metadata for a given version that coming across
+        Map<String, VersionMetadata> sourceVersions = source.getVersions();
+        for ( final String v : sourceVersions.keySet() )
+        {
+            VersionMetadata value = sourceVersions.get( v );
+            // if the versions meet are same here:
+            // for group merging, versions only accepts the first one coming to the group,
+            // for publish merging, it always accepts the latest updated version meta
+            if ( !isForGroup || !versions.containsKey( v ) )
+            {
+                versions.put( v, value );
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Repository.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/Repository.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+public class Repository
+{
+    private final String type;
+
+    private final String url;
+
+    protected Repository()
+    {
+        this.type = null;
+        this.url = null;
+    }
+
+    public Repository( final String url )
+    {
+        this.type = null;
+        this.url = url;
+    }
+
+    public Repository( final String type, final String url )
+    {
+        this.type = type;
+        this.url = url;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/UserInfo.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/UserInfo.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+public class UserInfo
+{
+    private final String name;
+
+    private final String email;
+
+    private final String url;
+
+    protected UserInfo()
+    {
+        this.name = null;
+        this.email = null;
+        this.url = null;
+    }
+
+    public UserInfo( final String name )
+    {
+        this.name = name;
+        this.email = null;
+        this.url = null;
+    }
+
+    public UserInfo( final String name, final String email )
+    {
+        this.name = name;
+        this.email = email;
+        this.url = null;
+    }
+
+    public UserInfo( final String name, final String email, final String url )
+    {
+        this.name = name;
+        this.email = email;
+        this.url = url;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getEmail()
+    {
+        return email;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( !( o instanceof UserInfo ) )
+        {
+            return false;
+        }
+
+        UserInfo that = (UserInfo) o;
+
+        return getName().equals( that.getName() );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        return result;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
+++ b/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
@@ -1,0 +1,488 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties( "_id" )
+public class VersionMetadata
+                implements Serializable, Comparable<VersionMetadata>
+{
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+
+    private String title;
+
+    private String description;
+
+    private String main;
+
+    private String version;
+
+    private String url;
+
+    private String homepage;
+
+    private List<String> keywords;
+
+    private UserInfo author;
+
+    private List<UserInfo> contributors;
+
+    private List<UserInfo> maintainers;
+
+    private Repository repository;
+
+    private Bugs bugs;
+
+    @Deprecated
+    private List<License> licenses;
+
+    private License license;
+
+    private Map<String, String> dependencies;
+
+    private Map<String, String> devDependencies;
+
+    private Map<String, String> jsdomVersions;
+
+    private Map<String, Object> scripts;
+
+    private Dist dist;
+
+    private Directories directories;
+
+    private Commitplease commitplease;
+
+    private List<Engines> engines;
+
+    @JsonProperty( "_engineSupported" )
+    private Boolean engineSupported;
+
+    private List<String> files;
+
+    private String deprecated;
+
+    private String lib;
+
+    private String gitHead;
+
+    @JsonProperty( "_shasum" )
+    private String shasum;
+
+    @JsonProperty( "_from" )
+    private String from;
+
+    @JsonProperty( "_npmVersion" )
+    private String npmVersion;
+
+    @JsonProperty( "_nodeVersion" )
+    private String nodeVersion;
+
+    @JsonProperty( "_npmUser" )
+    private UserInfo npmUser;
+
+    @JsonProperty( "_npmJsonOpts" )
+    private NpmJsonOpts npmJsonOpts;
+
+    @JsonProperty( "_npmOperationalInternal" )
+    private NpmOperationalInternal npmOperationalInternal;
+
+    @JsonProperty( "_defaultsLoaded" )
+    private Boolean defaultsLoaded;
+
+    public VersionMetadata()
+    {
+    }
+
+    public VersionMetadata( String name, String version )
+    {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName( String name )
+    {
+        this.name = name;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public void setTitle( String title )
+    {
+        this.title = title;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription( String description )
+    {
+        this.description = description;
+    }
+
+    public String getMain()
+    {
+        return main;
+    }
+
+    public void setMain( String main )
+    {
+        this.main = main;
+    }
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+    public void setVersion( String version )
+    {
+        this.version = version;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+    public void setUrl( String url )
+    {
+        this.url = url;
+    }
+
+    public String getHomepage()
+    {
+        return homepage;
+    }
+
+    public void setHomepage( String homepage )
+    {
+        this.homepage = homepage;
+    }
+
+    public List<String> getKeywords()
+    {
+        return keywords;
+    }
+
+    public void setKeywords( List<String> keywords )
+    {
+        this.keywords = keywords;
+    }
+
+    public UserInfo getAuthor()
+    {
+        return author;
+    }
+
+    public void setAuthor( UserInfo author )
+    {
+        this.author = author;
+    }
+
+    public List<UserInfo> getContributors()
+    {
+        return contributors;
+    }
+
+    public void setContributors( List<UserInfo> contributors )
+    {
+        this.contributors = contributors;
+    }
+
+    public List<UserInfo> getMaintainers()
+    {
+        return maintainers;
+    }
+
+    public void setMaintainers( List<UserInfo> maintainers )
+    {
+        this.maintainers = maintainers;
+    }
+
+    public Repository getRepository()
+    {
+        return repository;
+    }
+
+    public void setRepository( Repository repository )
+    {
+        this.repository = repository;
+    }
+
+    public Bugs getBugs()
+    {
+        return bugs;
+    }
+
+    public void setBugs( Bugs bugs )
+    {
+        this.bugs = bugs;
+    }
+
+    public List<License> getLicenses()
+    {
+        return licenses;
+    }
+
+    public void setLicenses( List<License> licenses )
+    {
+        this.licenses = licenses;
+    }
+
+    public License getLicense()
+    {
+        return license;
+    }
+
+    public void setLicense( License license )
+    {
+        this.license = license;
+    }
+
+    public Map<String, String> getDependencies()
+    {
+        return dependencies;
+    }
+
+    public void setDependencies( Map<String, String> dependencies )
+    {
+        this.dependencies = dependencies;
+    }
+
+    public Map<String, String> getDevDependencies()
+    {
+        return devDependencies;
+    }
+
+    public void setDevDependencies( Map<String, String> devDependencies )
+    {
+        this.devDependencies = devDependencies;
+    }
+
+    public Map<String, String> getJsdomVersions()
+    {
+        return jsdomVersions;
+    }
+
+    public void setJsdomVersions( Map<String, String> jsdomVersions )
+    {
+        this.jsdomVersions = jsdomVersions;
+    }
+
+    public Map<String, Object> getScripts()
+    {
+        return scripts;
+    }
+
+    public void setScripts( Map<String, Object> scripts )
+    {
+        this.scripts = scripts;
+    }
+
+    public Dist getDist()
+    {
+        return dist;
+    }
+
+    public void setDist( Dist dist )
+    {
+        this.dist = dist;
+    }
+
+    public Directories getDirectories()
+    {
+        return directories;
+    }
+
+    public void setDirectories( Directories directories )
+    {
+        this.directories = directories;
+    }
+
+    public Commitplease getCommitplease()
+    {
+        return commitplease;
+    }
+
+    public void setCommitplease( Commitplease commitplease )
+    {
+        this.commitplease = commitplease;
+    }
+
+    public List<Engines> getEngines()
+    {
+        return engines;
+    }
+
+    public void setEngines( List<Engines> engines )
+    {
+        this.engines = engines;
+    }
+
+    public Boolean getEngineSupported()
+    {
+        return engineSupported;
+    }
+
+    public void setEngineSupported( Boolean engineSupported )
+    {
+        this.engineSupported = engineSupported;
+    }
+
+    public List<String> getFiles()
+    {
+        return files;
+    }
+
+    public void setFiles( List<String> files )
+    {
+        this.files = files;
+    }
+
+    public String getDeprecated()
+    {
+        return deprecated;
+    }
+
+    public void setDeprecated( String deprecated )
+    {
+        this.deprecated = deprecated;
+    }
+
+    public String getLib()
+    {
+        return lib;
+    }
+
+    public void setLib( String lib )
+    {
+        this.lib = lib;
+    }
+
+    public String getGitHead()
+    {
+        return gitHead;
+    }
+
+    public void setGitHead( String gitHead )
+    {
+        this.gitHead = gitHead;
+    }
+
+    public String getShasum()
+    {
+        return shasum;
+    }
+
+    public void setShasum( String shasum )
+    {
+        this.shasum = shasum;
+    }
+
+    public String getFrom()
+    {
+        return from;
+    }
+
+    public void setFrom( String from )
+    {
+        this.from = from;
+    }
+
+    public String getNpmVersion()
+    {
+        return npmVersion;
+    }
+
+    public void setNpmVersion( String npmVersion )
+    {
+        this.npmVersion = npmVersion;
+    }
+
+    public String getNodeVersion()
+    {
+        return nodeVersion;
+    }
+
+    public void setNodeVersion( String nodeVersion )
+    {
+        this.nodeVersion = nodeVersion;
+    }
+
+    public UserInfo getNpmUser()
+    {
+        return npmUser;
+    }
+
+    public void setNpmUser( UserInfo npmUser )
+    {
+        this.npmUser = npmUser;
+    }
+
+    public NpmJsonOpts getNpmJsonOpts()
+    {
+        return npmJsonOpts;
+    }
+
+    public void setNpmJsonOpts( NpmJsonOpts npmJsonOpts )
+    {
+        this.npmJsonOpts = npmJsonOpts;
+    }
+
+    public NpmOperationalInternal getNpmOperationalInternal()
+    {
+        return npmOperationalInternal;
+    }
+
+    public void setNpmOperationalInternal( NpmOperationalInternal npmOperationalInternal )
+    {
+        this.npmOperationalInternal = npmOperationalInternal;
+    }
+
+    public Boolean getDefaultsLoaded()
+    {
+        return defaultsLoaded;
+    }
+
+    public void setDefaultsLoaded( Boolean defaultsLoaded )
+    {
+        this.defaultsLoaded = defaultsLoaded;
+    }
+
+    @Override
+    public int compareTo( VersionMetadata o )
+    {
+        return 0;
+    }
+}

--- a/core-java/src/main/java/org/commonjava/indy/util/PathUtils.java
+++ b/core-java/src/main/java/org/commonjava/indy/util/PathUtils.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.util;
+
+public final class PathUtils
+{
+
+    public static final String ROOT = "/";
+
+    private static final String[] ROOT_ARRY = { ROOT };
+
+    private PathUtils()
+    {
+    }
+
+    public static String[] parentPath( final String path )
+    {
+        final String[] parts = path.split( "/" );
+        if ( parts.length < 2 )
+        {
+            return ROOT_ARRY;
+        }
+        else
+        {
+            final String[] parentParts = new String[parts.length - 1];
+            System.arraycopy( parts, 0, parentParts, 0, parentParts.length );
+            return parentParts;
+        }
+    }
+
+    public static String normalize( final String... path )
+    {
+        if ( path == null || path.length < 1 || ( path.length == 1 && path[0] == null ) )
+        {
+            return ROOT;
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        int idx = 0;
+        parts:
+        for ( String part : path )
+        {
+            if ( part == null || part.length() < 1 || "/".equals( part ) )
+            {
+                continue;
+            }
+
+            if ( idx == 0 && part.startsWith( "file:" ) )
+            {
+                if ( part.length() > 5 )
+                {
+                    sb.append( part.substring( 5 ) );
+                }
+
+                continue;
+            }
+
+            if ( idx > 0 )
+            {
+                while ( part.charAt( 0 ) == '/' )
+                {
+                    if ( part.length() < 2 )
+                    {
+                        continue parts;
+                    }
+
+                    part = part.substring( 1 );
+                }
+            }
+
+            while ( part.charAt( part.length() - 1 ) == '/' )
+            {
+                if ( part.length() < 2 )
+                {
+                    continue parts;
+                }
+
+                part = part.substring( 0, part.length() - 1 );
+            }
+
+            if ( sb.length() > 0 )
+            {
+                sb.append( '/' );
+            }
+
+            sb.append( part );
+            idx++;
+        }
+
+        if ( path[path.length - 1] != null && path[path.length - 1].endsWith( "/" ) )
+        {
+            sb.append( "/" );
+        }
+
+        return sb.toString();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <projectEmail>https://github.com/Commonjava/indy-model</projectEmail>
-    <atlas-version>1.1.4</atlas-version>
+    <atlas-version>1.1.9</atlas-version>
     <quarkus-kafka-version>3.6.9</quarkus-kafka-version>
     <logback-version>1.2.13</logback-version>
     <jackson-version>2.15.2</jackson-version>


### PR DESCRIPTION
- Upgrade org.commonjava.atlas from 1.1.4 to 1.1.9 for bug fixes
- Add NPM package model classes (13 models + 1 content class) from indy-promote-service
- Add PathUtils utility class for path normalization
- All model classes are pure POJOs without API documentation annotations

These NPM models are now shared in indy-model for reuse across services, eliminating duplication and providing a single source of truth for NPM metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)