### PR TITLE
Update atlas to 1.1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <projectEmail>https://github.com/Commonjava/indy-model</projectEmail>
-    <atlas-version>1.1.4</atlas-version>
+    <atlas-version>1.1.9</atlas-version>
     <quarkus-kafka-version>3.6.9</quarkus-kafka-version>
     <logback-version>1.2.13</logback-version>
     <jackson-version>2.15.2</jackson-version>


### PR DESCRIPTION
Update atlas to 1.1.9, which fix ArtifactPathInfo to reject non-standard paths.