### PR TITLE
Update GitHub workflows to match atlas pattern

### DIFF
--- a/.github/workflows/merge-build.yml
+++ b/.github/workflows/merge-build.yml
@@ -19,41 +19,50 @@
 
 name: Merge / Push Build
 
-on: [push]
+on:
+  watch:
+    types: [started]
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
 
 jobs:
-  publish-snapshot:
-    name: publish to oss sonatype
-
+  build:
+    name: Build with maven
     runs-on: ubuntu-latest
-
-    permissions: 
-      contents: read
-      packages: write
-
+    env:
+      MAVEN_OPTS: "-Xmx4096m -Xms2048m -XX:MaxMetaspaceSize=4096m -Xss8m"
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up JDK
+    - name: Set up JDK 11 for x64
       uses: actions/setup-java@v3
       with:
+        java-version: '11'
         distribution: 'temurin'
         architecture: x64
-        java-version: 11
 
-    - name: maven-settings-xml-action
-      uses: whelk-io/maven-settings-xml-action@v14
-      if: ${{ github.event.repository.fork == false }}
+    - uses: s4u/maven-settings-action@v2.8.0
       with:
-        repositories: '[{ "id": "sonatype", "url": "https://oss.sonatype.org/content/repositories/snapshots/", "releases": {"enabled": "false"}, "snapshots": {"enabled": "true" }}]'
-        servers: '[{ "id": "sonatype", "username": "${{ secrets.SONATYPE_BOT_USERNAME}}", "password": "${{ secrets.SONATYPE_BOT_TOKEN}}" }]'
+        sonatypeSnapshots: true
 
-    - name: "Maven Build & Deploy Snapshot to Sonatype OSSRH"
-      if: ${{ github.event.repository.fork == false }}
+    - name: Build the Maven verify phase
+      run: mvn -B -V clean verify -Prun-its
 
-      run: mvn -B -e deploy -DaltDeploymentRepository=sonatype::default::https://oss.sonatype.org/content/repositories/snapshots/
+    - uses: s4u/maven-settings-action@v2.8.0
+      if: ${{ github.event_name == 'push' }}
+      with:
+        servers: |
+          [{
+              "id": "central-portal-snapshots",
+              "username": "${{ secrets.SONATYPE_BOT_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_BOT_TOKEN }}"
+          }]
 
-    - name: "Maven Build"
-      if: ${{ github.event.repository.fork == true }}
-
-      run: mvn -B -e -Prun-its verify
+    - name: Deploy the artifact
+      if: ${{ github.event_name == 'push' }}
+      run: mvn help:effective-settings -B -V clean deploy -e

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,27 +19,29 @@
 
 name: PR Build
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
 
 jobs:
   build:
-
+    name: Build with maven
     runs-on: ubuntu-latest
-
+    env:
+      MAVEN_OPTS: "-Xmx4096m -Xms2048m -XX:MaxMetaspaceSize=4096m -Xss8m"
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up JDK
+    - name: Set up JDK 11 for x64
       uses: actions/setup-java@v3
       with:
+        java-version: '11'
         distribution: 'temurin'
         architecture: x64
-        java-version: 11
 
-    - name: maven-settings-xml-action
-      uses: whelk-io/maven-settings-xml-action@v14
+    - uses: s4u/maven-settings-action@v2.8.0
       with:
-        repositories: '[{ "id": "sonatype", "url": "https://oss.sonatype.org/content/repositories/snapshots/", "releases": {"enabled": "false"}, "snapshots": {"enabled": "true" }}]'
+        sonatypeSnapshots: true
 
     - name: Build with Maven
-      run: mvn -Prun-its -B -e verify
+      run: mvn -B -V clean verify -Prun-its


### PR DESCRIPTION
- Add explicit branch trigger (main) instead of wildcard push
- Add workflow_dispatch for manual triggering
- Switch from whelk-io/maven-settings-xml-action to s4u/maven-settings-action@v2.8.0
- Replace fork detection logic with event-based deployment (push vs PR)
- Update Sonatype server ID to central-portal-snapshots
- Add MAVEN_OPTS for better build performance
- Add watch trigger for starred repo builds
- Specify PR event types explicitly
- Make build and deployment steps clearer

This fixes the "Workflow runs completed with no jobs" issue by:
1. Making triggers more explicit
2. Simplifying conditional logic
3. Using more modern and reliable GitHub Actions